### PR TITLE
Abate LinkMod, and add "mysterious liquid" death

### DIFF
--- a/dwtd_bryce1_pissed_off_chief.rpy
+++ b/dwtd_bryce1_pissed_off_chief.rpy
@@ -1,16 +1,18 @@
-init:
-    find label bryce1
-    search say "You know, I'm just about done here for the day, but if you want to discuss it over a beer or something, I'd be more than happy." as dwtd_pissed_off_chief_check_in
-    search menu "I don't usually drink, though." as dwtd_pissed_off_chief_check_out
-    callto label dwtd_pissed_off_chief_check from dwtd_pissed_off_chief_check_in return dwtd_pissed_off_chief_check_out
-    branch "I don't usually drink, though."
-    search menu "[[press him about wanting to go to a bar.]"
-    branch "[[press him about wanting to go to a bar.]"
-    search menu "It can't be that hard."
-    branch "It can't be that hard."
-    search say "Alright, kiddo, that's enough. You better go now before you make me really mad." as dwtd_pissed_off_chief_menu_in
-    search say "I might not be the wisest person that ever lived, but if I knew one thing, it was that getting on a dragon's bad side was not a very good idea." as dwtd_pissed_off_chief_menu_out
-    callto label dwtd_pissed_off_chief_menu from dwtd_pissed_off_chief_menu_in return dwtd_pissed_off_chief_menu_out
+init python:
+    def dwtd_pissed_off_chief_link(ml):
+        (ml.find_label('bryce1')
+            .search_say("You know, I'm just about done here for the day, but if you want to discuss it over a beer or something, I'd be more than happy.")
+            .hook_call_to("dwtd_pissed_off_chief_check")
+            .search_menu()
+            .branch("I don't usually drink, though.")
+            .search_menu()
+            .branch("[[press him about wanting to go to a bar.]")
+            .search_menu()
+            .branch("It can't be that hard.")
+            .search_say("Alright, kiddo, that's enough. You better go now before you make me really mad.")
+            .hook_call_to("dwtd_pissed_off_chief_menu")
+        )
+    dwtd_pissed_off_chief_link(magmalink())
 
 label dwtd_pissed_off_chief_check:
     if not dwtd.check_keypoint():
@@ -28,16 +30,11 @@ label dwtd_pissed_off_chief_check:
         show bryce stern b with dissolve
         Br "Alright, kiddo, that's enough. You better go now before you make me really mad."
         jump dwtd_pissed_off_chief_death
-    else:
-        $ brycemood = 0
-        return
+    return
 
 label dwtd_pissed_off_chief_menu:
     menu:
         "[[leave]":
-            stop music fadeout 1.0
-            scene black with fade
-            nvl clear
             return
         "[[make fun of him]":
             label dwtd_pissed_off_chief_death:

--- a/dwtd_bryce1_tickled_dragon.rpy
+++ b/dwtd_bryce1_tickled_dragon.rpy
@@ -1,9 +1,12 @@
-init:
-    find say "(Guess I must have passed out after I got Bryce home.)"
-    callto label dwtd_draco_domiens_check
-
-    search menu "Wake up, fattie."
-    add option "[[tickle him]" to dwtd_draco_domiens_death
+init python:
+    def dwtd_draco_domiens_link(ml):
+        (ml.find_label('bryce1')
+            .search_say("(Guess I must have passed out after I got Bryce home.)", depth = 1000)
+            .hook_call_to('dwtd_draco_domiens_check')
+            .search_menu()
+            .add_choice('[[Tickle him.]', jump = 'dwtd_draco_domiens_death')
+        )
+    dwtd_draco_domiens_link(magmalink())
 
 label dwtd_draco_domiens_check:
     if not dwtd.check_keypoint():
@@ -12,8 +15,7 @@ label dwtd_draco_domiens_check:
         $ renpy.pop_call()
         c "Hey, Bryce."
         jump dwtd_draco_domiens_death
-    else:
-        return
+    return
 
 label dwtd_draco_domiens_death:
     $ dwtd.will_die()

--- a/dwtd_c1_mysteryliquid.rpy
+++ b/dwtd_c1_mysteryliquid.rpy
@@ -1,0 +1,27 @@
+init python:
+    def dwtd_c1_mysteryliquid_link(ml):
+        (ml.find_label("menufridge")
+            .search_menu()
+            .branch("Examine an unlabeled container.")
+            .search_say("(It's salty.)")
+            .hook_to("dwtd_c1_mysteryliquid_drink")
+            .search_if()
+            .hook_to("dwtd_c1_mysteryliquid_achievement")
+        )
+    dwtd_c1_mysteryliquid_link(magmalink())
+
+label dwtd_c1_mysteryliquid_drink:
+    $ dwtd.will_die()
+    c "(Hmm. I don't feel so...)"
+    play sound "fx/platecrash.ogg"
+    stop music fadeout 1.5
+    $ renpy.pause(1.5)
+    scene black with dissolvemed
+    play sound "fx/impact.wav"
+    $ renpy.pause(4.0)
+    show dwtd_youdied_text at top with easeintop
+    # But it's okay, you get an achievement, bucko!
+    jump dwtd_c1_mysteryliquid_drink_return
+
+label dwtd_c1_mysteryliquid_achievement:
+    call dwtd_youdied("Drank a Mysterious Liquid", "You decided to drink a liquid that you knew absolutely nothing about.")

--- a/dwtd_c1_painmeds.rpy
+++ b/dwtd_c1_painmeds.rpy
@@ -1,13 +1,17 @@
-init:
-    find label menu5
-    callto label dwtd_c1_painmeds_check
-    find label medmenu
-    search menu "Take some."
-    branch "Take some."
-    search if "medstaken == 2"
-    branch "medstaken == 2"
-    search say "(Can't hurt... because they're pain meds. Hehe.)"
-    callto label dwtd_c1_painmeds_death
+init python:
+    def dwtd_c1_painmeds_link(ml):
+        (ml.find_label('menu5')
+            .hook_call_to('dwtd_c1_painmeds_check')
+        )
+        (ml.find_label('medmenu')
+            .search_menu()
+            .branch('Take some.')
+            .search_if('medstaken == 2')
+            .branch()
+            .search_say("(Can't hurt... because they're pain meds. Hehe.)")
+            .hook_to('dwtd_c1_painmeds_death')
+        )
+    dwtd_c1_painmeds_link(magmalink())
 
 label dwtd_c1_painmeds_check:
     if not dwtd.check_keypoint():
@@ -27,12 +31,10 @@ label dwtd_c1_painmeds_check:
         c "(I suppose one more can't hurt.){w=1.0}{nw}"
         c "(Can't hurt... because they're pain meds. Hehe.){w=1.0}{nw}"
         jump dwtd_c1_painmeds_death
-    else:
-        return
+    return
         
 
 label dwtd_c1_painmeds_death:
-    $ renpy.pop_call()
     $ dwtd.will_die()
     play sound "fx/meds.wav"
     $ renpy.pause(1.5)


### PR DESCRIPTION
One, but not all, of the LinkMod abatements was tested.

Presently, the "mysterious liquid" death isn't forced in hardcore mode, because it seems difficult to shoehorn into a context where that is forced to happen.